### PR TITLE
Build failed due to missing tailwind css

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.html",
   "scripts": {
     "dev": "npx serve .",
+    "build": "echo 'Static site - no build required'",
     "deploy": "vercel --prod",
     "deploy:preview": "vercel",
     "setup": "npm run setup:vercel && npm run setup:cloudflare",

--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,11 @@
 {
   "version": 2,
   "name": "boutique-junior",
-  "builds": [
-    {
-      "src": "index.html",
-      "use": "@vercel/static"
-    }
-  ],
+  "framework": null,
+  "buildCommand": "echo 'Static site - no build required'",
+  "outputDirectory": ".",
+  "installCommand": "echo 'No dependencies to install'",
+  "devCommand": "npx serve .",
   "routes": [
     {
       "src": "/(.*)",


### PR DESCRIPTION
Configure Vercel to explicitly treat the project as a static site to resolve build failures.

The build was failing because Vercel was incorrectly detecting the project as a Next.js application, attempting to compile it and failing to find `tailwindcss`. These changes disable automatic framework detection and provide explicit commands for a static site.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1115c14-ffec-4372-8535-25c59ca155d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b1115c14-ffec-4372-8535-25c59ca155d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

